### PR TITLE
case-insensitive commit keywords

### DIFF
--- a/src/main/groovy/com/productmadness/plugin/util/CommandUtil.groovy
+++ b/src/main/groovy/com/productmadness/plugin/util/CommandUtil.groovy
@@ -31,7 +31,7 @@ class CommandUtil {
     static String formGrepTemplate(int startIndex, int length) {
         def grepTemplate = new StringBuilder()
         (startIndex..(startIndex + length - 1)).each {
-            grepTemplate.append("--grep %$it\$s")
+            grepTemplate.append("--grep -i %$it\$s")
         }
 
         return grepTemplate.replaceAll("(?!^)--grep", " --grep").toString()


### PR DESCRIPTION
For example, in case [minor] is specified as a keyword, [Minor]/[MINOR]/etc. will work as well